### PR TITLE
mtp-responder: Disable device icon by default

### DIFF
--- a/src/mtp_entity_device.c
+++ b/src/mtp_entity_device.c
@@ -366,10 +366,12 @@ static mtp_bool __init_device_props()
 	i++;
 #endif /*MTP_SUPPORT_DEVICE_CLASS*/
 
+#ifdef MTP_SUPPORT_DEVICE_ICON
 	dev_prop = &(g_device.device_prop_list[i]);
 	_prop_init_device_property_desc(dev_prop, MTP_PROPERTYCODE_DEVICEICON,
 			PTP_DATATYPE_AUINT8, PTP_PROPGETSET_GETONLY, NONE);
 	i++;
+#endif /*MTP_SUPPORT_DEVICE_ICON*/
 
 	already_init = TRUE;
 


### PR DESCRIPTION
## Summary
mtp-responder: Disable device icon by default.
Some device not support device icon very well.

![image](https://github.com/user-attachments/assets/a03a0156-078d-49d3-90eb-d096a8e0905f)
```
ap> hexdump /vendor/mtp/device_icon.ico skip=0 count=16
/vendor/mtp/device_icon.ico at :
0000: 00 00 01 00 01 00 00 00 00 00 01 00 20 00 47 9b ............ .G.
ap> hexdump /vendor/mtp/device_icon.ico skip=39757 count=16
/vendor/mtp/device_icon.ico at :
0000: e8 1a 97 c9 00 00 00 00 49 45 4e 44 ae 42 60 82 ........IEND.B`.
```

## Impact
mtp-responder

## Testing
Self test with customed board succ.



