### PR TITLE
mtp-responder: Send an additional zero length packet if length of data is a multiple of packet size

### DIFF
--- a/src/ptp_container.c
+++ b/src/ptp_container.c
@@ -18,6 +18,7 @@
 #include "ptp_container.h"
 #include "ptp_datacodes.h"
 #include "mtp_transport.h"
+#include "mtp_usb_driver.h"
 #include "mtp_util_support.h"
 #include "mtp_util.h"
 
@@ -178,6 +179,9 @@ mtp_bool _hdlr_send_data_container(data_container_t *dst)
 
 	if (sent != dst->len)
 		return FALSE;
+
+	if ((sent % _transport_get_usb_packet_len()) == 0)
+		_transport_send_zlp();
 
 	return TRUE;
 }


### PR DESCRIPTION
## Summary
external/mtp-responder: Send an additional zero length packet if length of data is a multiple of packet size.
To support connecting to macOS.

#### Host log
> No response after GetStorageInfo.
```
2024/03/28 15:28:06 MTP decoded &mtp.Uint32Array{Values:[]uint32{0x20001}}
2024/03/28 15:28:06 MTP request GetStorageInfo [131073]

send: 0x10 bytes with ep 0x3:
0000: 1000 0000 0100 0510 0300 0000 0100 0200  ................

recv: 0x40 bytes with ep 0x82:
0000: 4000 0000 0200 0510 0300 0000 0400 0200  @...............
0010: 0000 0000 e055 0600 0000 0000 00ca 0400  .....U..........
0020: 0000 ffff ffff 0543 0061 0072 0064 0000  .......C.a.r.d..
0030: 0007 2d00 3200 3000 3000 3000 3100 0000  ..-.2.0.0.0.1...
2024/03/28 15:28:06 MTP data 0x40 bytes

recv: 0xc bytes with ep 0x82:
0000: 0c00 0000 0300 0120 0300 0000            ....... ....

2024/03/28 15:28:06 MTP bulk read 0xc bytes.
2024/03/28 15:28:21 MTP response 0x0 []
2024/03/28 15:28:21 fatal error got type 0 (CONTAINER_UNDEFINED) in response, want CONTAINER_RESPONSE.; closing connection.
```
## Impact
mtp-responder

## Testing
CI