### PR TITLE
mtp-responder: Disable property "Perceived Device Type"(0xd407)

### DIFF
--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -56,7 +56,7 @@
 /*#define MTP_SUPPORT_INTERDEPENDENTPROP*/
 
 /*mobile class. this should be set with ms os descriptor. see portable device installation consideration */
-#define MTP_SUPPORT_DEVICE_CLASS
+/*#define MTP_SUPPORT_DEVICE_CLASS*/
 
 /*#define MTP_SUPPORT_WMV_ENCODINGPROFILE */		/* for WMV encoding profile */
 


### PR DESCRIPTION
## Summary
external/mtp-responder: Disable property "Perceived Device Type"(0xd407)
The property "Perceived Device Type"(0xd407) has not beed supported yet, it should not be reported in response when received "GetDeviceInfo"(0x1001) operation.

#### Log
```
[03/03 03:21:16] [143] [ap] [MTP-RESPONDER] COMMAND ======== GET DEVICE PROP DESC ===========
[03/03 03:21:16] [143] [ap] [MTP-RESPONDER] Unknown PropId : [0xd407]
[03/03 03:21:16] [143] [ap] [MTP-RESPONDER] [SUCCESS], Opcode[0x1014], ResponseCode[0x2001], NumParams[0]
```
## Impact
mtp-responder

## Testing
CI