### PR TITLE
mtp-responder: Reserve space for system, loop write all data and add support for `URB_CONTROL`

### DIFF
--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -41,7 +41,7 @@
 /* Support Features */
 
 /* cancel transactio, device reset, mainly used in mtpmain.c */
-/* #define MTP_SUPPORT_CONTROL_REQUEST */
+#define MTP_SUPPORT_CONTROL_REQUEST
 
 #define MTP_SUPPORT_ALBUM_ART		/* album art image file */
 /*#define MTP_SUPPORT_DELETE_MEDIA_ALBUM_FILE*/

--- a/src/mtp_cmd_handler.c
+++ b/src/mtp_cmd_handler.c
@@ -3187,8 +3187,6 @@ void _receive_mq_data_cb(mtp_char *buffer, mtp_int32 buf_len)
 		cmd_container_t *tmp;
 		mtp_dword len = 0;
 		mtp_word type = 0;
-		mtp_word code = 0;
-		mtp_dword trid = 0;
 
 		if (buffer == NULL)
 			return;
@@ -3215,11 +3213,9 @@ void _receive_mq_data_cb(mtp_char *buffer, mtp_int32 buf_len)
 
 		len = tmp->len;
 		type = tmp->type;
-		code = tmp->code;
-		trid = tmp->tid;
 
 		DBG("len[%lu], type[0x%x], code [0x%x], trid[0x%lu]\n",
-				len, type, code, trid);
+				len, type, tmp->code, tmp->tid);
 
 		if (_hdlr_validate_cmd_container((mtp_byte *)tmp, len)
 				== FALSE) {

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -560,7 +560,7 @@ static inline int _main_init(void)
 static gboolean usb_hotplug_cb(GIOChannel *chan, GIOCondition cond, gpointer data)
 {
 	char buffer[256];
-	size_t ret;
+	mtp_int32 ret;
 	char *p;
 
 	ret = read(g_io_channel_unix_get_fd(chan), buffer, sizeof(buffer));

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -564,6 +564,10 @@ static gboolean usb_hotplug_cb(GIOChannel *chan, GIOCondition cond, gpointer dat
 	char *p;
 
 	ret = read(g_io_channel_unix_get_fd(chan), buffer, sizeof(buffer));
+	if (ret < 0) {
+		ERR("usb_hotplug_cb() read notify event Fail:%d", errno);
+		return FALSE;
+	}
 
 	for (p = buffer; p < buffer + ret;) {
 		struct inotify_event *event = (struct inotify_event *)p;
@@ -588,7 +592,7 @@ static gboolean usb_hotplug_cb(GIOChannel *chan, GIOCondition cond, gpointer dat
 #ifndef TIZEN_TEST_GTESTS
 int main(int argc, char *argv[])
 {
-	mtp_int32 ret;
+	mtp_int32 ret = -1;
 	pthread_mutexattr_t mutex_attr;
 #ifdef MTP_SUPPORT_CHECK_HOTPLUG_BY_NOTIFY
 	mtp_int32 fd = -1;

--- a/src/mtp_port.c
+++ b/src/mtp_port.c
@@ -158,7 +158,7 @@ char* vconf_get_str(const char* key)
 
 int vconf_set_str(const char* key, const char* strval)
 {
-    if (property_set_buffer(key, strval, sizeof(strval)) < 0) {
+    if (property_set_buffer(key, strval, strlen(strval)) < 0) {
         return -1;
     }
 

--- a/src/mtp_usb_driver.c
+++ b/src/mtp_usb_driver.c
@@ -32,7 +32,7 @@ mtp_bool _transport_select_driver(void)
 		return TRUE;
 	}
 
-	if (access(MTP_EP_IN_PATH, F_OK) == 0 || sd_listen_fds(0) >= 4) {
+	if (access(MTP_EP0_PATH, F_OK) == 0 || sd_listen_fds(0) >= 4) {
 		usb_driver = &mtp_usb_driver_ffs;
 		DBG("FFS driver selected");
 		return TRUE;

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -113,8 +113,6 @@ static mtp_bool ffs_transport_init_usb_device(void)
     pkt_size.tx = g_conf.write_usb_size;
     DBG("Final : Tx pkt size:[%u], Rx pkt size:[%u]\n", pkt_size.tx, pkt_size.rx);
     msg_size = sizeof(msgq_ptr_t) - sizeof(long);
-    if (msg_size < CONFIG_MQ_MAXMSGSIZE)
-	    msg_size = CONFIG_MQ_MAXMSGSIZE;
     rx_mq_sz = (g_conf.max_io_buf_size / g_conf.max_rx_ipc_size) * msg_size;
     tx_mq_sz = (g_conf.max_io_buf_size / g_conf.max_tx_ipc_size) * msg_size;
     DBG("RX MQ size :[%u], TX MQ size:[%u]\n", rx_mq_sz, tx_mq_sz);

--- a/src/mtp_util_fs.c
+++ b/src/mtp_util_fs.c
@@ -809,6 +809,7 @@ mtp_bool _util_get_filesystem_info_ext(mtp_char *storepath,
 	mtp_uint64 avail_size = 0;
 	mtp_uint64 capacity = 0;
 	mtp_uint64 used_size = 0;
+	mtp_uint64 reserved = 1024ull *1024 *1024;
 
 	if (statfs(storepath, &buf) != 0) {
 		ERR("statfs is failed\n");
@@ -818,12 +819,13 @@ mtp_bool _util_get_filesystem_info_ext(mtp_char *storepath,
 	capacity = used_size = avail_size = (mtp_uint64)buf.f_bsize;
 	DBG("Block size : %lu\n", (unsigned long)buf.f_bsize);
 	capacity *= buf.f_blocks;
+
 	used_size *= (buf.f_blocks - buf.f_bavail);
 	avail_size *= buf.f_bavail;
 
-	fs_info->disk_size = capacity;
+	fs_info->disk_size = capacity - reserved;
 	fs_info->reserved_size = used_size;
-	fs_info->avail_size = avail_size;
+	fs_info->avail_size = avail_size - reserved;
 
 	return TRUE;
 }


### PR DESCRIPTION
## Summary
1. Loop write all data
2. Fix warning/error reported by coverity (3 commits)
3.  Reserve 1GB space for system
4. Add support for URB_CONTROL/setup(`MTP_SUPPORT_CONTROL_REQUEST`) 
5. Remove message queue workaround - https://github.com/open-vela/external_mtp-responder/pull/5/commits/e0bef0c874b7ede89c3870baf6b12178975267b0 

## Impact
mtp-responder

## Testing
CI