### PR TITLE
mtp-responder: Fix busyloop and add more config for MTP (27~32)

### DIFF
--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -179,6 +179,11 @@
 #define MTP_MODEL_NAME_LEN_MAX		32
 #define MTP_DEVICE_NAME_LEN_MAX		64
 
+/* The priority of thread */
+#ifndef MTP_DEFAULT_THREAD_PRIORITY
+#define MTP_DEFAULT_THREAD_PRIORITY	100
+#endif
+
 /* The stack size of thread */
 #define MTP_DEFAULT_STACK_SIZE		8192
 #define MTP_TRANSPORT_STACK_SIZE	32768

--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -86,11 +86,16 @@
  * Transport related configuration
  */
 /* Internal Storage */
+#ifndef MTP_INTERNAL_PATH_CHAR
 #define MTP_INTERNAL_PATH_CHAR		"/log/"
+#endif
 
 /* External Storage */
 #define MTP_EXTERNAL_PATH_CHAR		"/data/"
+
+#ifndef MTP_DEVICE_ICON
 #define MTP_DEVICE_ICON			"/data/mtp/device_icon.ico"
+#endif
 
 /* File For WMP extesions */
 #define MTP_FILES_MODIFIED_FILES	"/tmp/mtp_mod_files.log"
@@ -127,10 +132,16 @@
 #define MTP_STORAGE_DESC_EXT		"Card"
 
 /*Devices Property*/
+#ifndef MTP_DEFAULT_MODEL_NAME
 #define MTP_DEFAULT_MODEL_NAME			"Xiaomi Watch"
+#endif
+
 #define MTP_DEFAULT_DEVICE_VERSION		"1.0"
 #define MTP_DEV_PROPERTY_SYNCPARTNER		"None"
+#ifndef MTP_DEV_PROPERTY_FRIENDLYNAME
 #define MTP_DEV_PROPERTY_FRIENDLYNAME		"Xiaomi Watch"
+#endif
+
 #define MTP_DEV_PROPERTY_NULL_SYNCPARTNER	"{00000000-0000-0000-0000-000000000000}"
 
 /*temporary file*/
@@ -177,6 +188,16 @@
  */
 /*#define MTP_USE_DEPEND_DEFAULT_MEMORY*/
 #define MTP_SUPPORT_OMADRM_EXTENSION
+
+/* The external storage directory list */
+#ifndef MTP_EXTERNAL_STORAGE_DICLIST
+#define MTP_EXTERNAL_STORAGE_DICLIST    ""
+#endif
+
+/* The reserved space of external storage */
+#ifndef MTP_EXTERNAL_STORAGE_RESERVED_SPACE
+#define MTP_EXTERNAL_STORAGE_RESERVED_SPACE 1024 //unit in MB
+#endif
 
 /* Image Height/Width */
 #define MTP_MAX_IMG_WIDTH		32672

--- a/src/mtp_entity_store.c
+++ b/src/mtp_entity_store.c
@@ -1199,7 +1199,7 @@ void _entity_store_recursive_enum_folder_objects(mtp_store_t *store,
 		if (file_name[0] == '.') {
 			DBG_SECURE("Hidden file [%s]\n", entry.filename);
 		} else if (entry.type == MTP_DIR_TYPE) {
-			if (strstr(entry.filename, "map") == NULL)
+			if (strstr(entry.filename, MTP_EXTERNAL_STORAGE_DICLIST) == NULL)
 				goto NEXT;
 
 			obj = _entity_add_folder_to_store(store, h_parent,
@@ -1212,7 +1212,7 @@ void _entity_store_recursive_enum_folder_objects(mtp_store_t *store,
 
 			_entity_store_recursive_enum_folder_objects(store, obj);
 		} else if (entry.type == MTP_FILE_TYPE) {
-			if (strstr(entry.filename, "map") == NULL)
+			if (strstr(entry.filename, MTP_EXTERNAL_STORAGE_DICLIST) == NULL)
 				goto NEXT;
 
 			_entity_add_file_to_store(store, h_parent,

--- a/src/mtp_event_handler.c
+++ b/src/mtp_event_handler.c
@@ -132,6 +132,8 @@ mtp_bool _eh_handle_usb_events(mtp_uint32 type)
 			break;
 		}
 
+		ERR("USB is connected");
+
 		res = pipe(g_pipefd);
 		if (res < 0) {
 			ERR("pipe() Fail");
@@ -159,7 +161,7 @@ mtp_bool _eh_handle_usb_events(mtp_uint32 type)
 
 		is_usb_inserted = 0;
 		is_usb_removed = 1;
-		DBG("USB is disconnected");
+		ERR("USB is disconnected");
 
 		_transport_set_usb_discon_state(TRUE);
 		_transport_set_cancel_initialization(TRUE);
@@ -459,7 +461,7 @@ void _eh_send_event_req_to_eh_thread(event_code_t action, mtp_ulong param1,
 	event.param2 = param2;
 	event.param3 = (mtp_ulong)param3;
 
-	DBG("action[%d], param1[%ld], param2[%ld]\n", action, param1, param2);
+	ERR("action[%d], param1[%ld], param2[%ld]\n", action, param1, param2);
 
 	status = write(g_pipefd[1], &event, sizeof(mtp_event_t));
 	if (status == -1 || errno == EINTR) {

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -74,7 +74,7 @@ static void __mtp_exit(void)
 
 	g_is_send_object = FALSE;
 
-	DBG("## Terminate all threads");
+	ERR("## Terminate all threads");
 	if (g_eh_thrd && g_eh_thrd != pthread_self()) {
 		_eh_send_event_req_to_eh_thread(EVENT_USB_REMOVED, 0, 0, NULL);
 		if (_util_thread_join(g_eh_thrd, NULL) == FALSE)

--- a/src/mtp_port.c
+++ b/src/mtp_port.c
@@ -135,7 +135,7 @@ char* vconf_get_str(const char* key)
     char* pstr = malloc(PROP_VALUE_MAX);
 
     if (strcmp(key, VCONFKEY_SETAPPL_DEVICE_NAME_STR) == 0) {
-        strlcpy(pstr, "XiaoMi Watch", PROP_VALUE_MAX);
+        strlcpy(pstr, "Xiaomi Watch S Ultra", PROP_VALUE_MAX);
     } else if (strcmp(key, VCONFKEY_MTP_SYNC_PARTNER_STR) == 0) {
         strlcpy(pstr, MTP_DEV_PROPERTY_SYNCPARTNER, PROP_VALUE_MAX);
     } else {

--- a/src/mtp_port.c
+++ b/src/mtp_port.c
@@ -135,7 +135,7 @@ char* vconf_get_str(const char* key)
     char* pstr = malloc(PROP_VALUE_MAX);
 
     if (strcmp(key, VCONFKEY_SETAPPL_DEVICE_NAME_STR) == 0) {
-        strlcpy(pstr, "Xiaomi Watch S Ultra", PROP_VALUE_MAX);
+        strlcpy(pstr, MTP_DEFAULT_MODEL_NAME, PROP_VALUE_MAX);
     } else if (strcmp(key, VCONFKEY_MTP_SYNC_PARTNER_STR) == 0) {
         strlcpy(pstr, MTP_DEV_PROPERTY_SYNCPARTNER, PROP_VALUE_MAX);
     } else {

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -452,7 +452,7 @@ static void* ffs_transport_thread_usb_control(void* arg)
         status = read(g_usb_ep0, &event, sizeof(event));
         if (status < 0) {
             ERR("read from ep0 failed: %d", errno);
-            continue;
+            break;
         }
 
         ERR("SETUP: type:%d request:%d value:%d index:%d length:%d\n",

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -206,8 +206,8 @@ static void* ffs_transport_thread_usb_write(void* arg)
                     continue;
                 }
 
-                if ((fds[0].revents & POLLOUT) == 0) {
-                    continue;
+                if ((fds[0].revents & POLLHUP) == POLLHUP) {
+                    break;
                 }
 
                 status = write(g_usb_ep_in, mtp_buf + written, len - written);

--- a/src/mtp_util.c
+++ b/src/mtp_util.c
@@ -295,8 +295,10 @@ void _util_get_lock_status(phone_status_t *val)
 
 	if (state)
 		*val = MTP_PHONE_LOCK_ON;
+#ifndef MTP_INTERNAL_STORAGE_LOCK_ON
 	else
 		*val = MTP_PHONE_LOCK_OFF;
+#endif
 	return;
 }
 /* LCOV_EXCL_STOP */

--- a/src/mtp_util_fs.c
+++ b/src/mtp_util_fs.c
@@ -809,7 +809,7 @@ mtp_bool _util_get_filesystem_info_ext(mtp_char *storepath,
 	mtp_uint64 avail_size = 0;
 	mtp_uint64 capacity = 0;
 	mtp_uint64 used_size = 0;
-	mtp_uint64 reserved = 1024ull *1024 *1024;
+	mtp_uint64 reserved = MTP_EXTERNAL_STORAGE_RESERVED_SPACE * 1024ull * 1024;
 
 	if (statfs(storepath, &buf) != 0) {
 		ERR("statfs is failed\n");

--- a/src/mtp_util_thread.c
+++ b/src/mtp_util_thread.c
@@ -24,6 +24,7 @@ mtp_bool _util_thread_create_with_stack(pthread_t *tid, const mtp_char *tname,
 {
 	int error = 0;
 	pthread_attr_t attr;
+	struct sched_param param;
 
 	retv_if(tname == NULL, FALSE);
 	retv_if(thread_func == NULL, FALSE);
@@ -45,6 +46,9 @@ mtp_bool _util_thread_create_with_stack(pthread_t *tid, const mtp_char *tname,
 			/* LCOV_EXCL_STOP */
 		}
 	}
+
+	param.sched_priority = MTP_DEFAULT_THREAD_PRIORITY;
+	pthread_attr_setschedparam(&attr, &param);
 
 	pthread_attr_setstacksize(&attr, stacksize);
 	error = pthread_create(tid, &attr, thread_func, arg);


### PR DESCRIPTION
## Summary
 (27~32, (6 commits), total: 49)
1. Break write if the peer closed its EP
2. Update device name from "XiaoMi Watch" to "Xiaomi Watch S Ultra"  - `MTP_DEFAULT_MODEL_NAME` (Link:  #6  )
3. Fix busyloop when usb disconnect
4. More debug log
5. Add config for MTP
6. Add MTP default priority for read/write/setup

## Impact
external/mtp-responder

## Testing
CI
