### PR TITLE
mtp-responder: Fixed the issue that getting average speed of transferring on macOS failed

### DIFF
--- a/src/mtp_cmd_handler.c
+++ b/src/mtp_cmd_handler.c
@@ -3417,8 +3417,9 @@ static mtp_bool __receive_temp_file_next_packets(mtp_char *data,
 		elapsed  = (((uint64_t)end_time.tv_sec * NSEC_PER_SEC) + end_time.tv_nsec);
 		elapsed -= (((uint64_t)start_time.tv_sec * NSEC_PER_SEC) + start_time.tv_nsec);
 		elapsed /= NSEC_PER_USEC;
-		ERR("mtp statistics log name: %s, file_size:%llu, speed:%u KB/s\n", g_mgr->ftemp_st.filepath, g_mgr->ftemp_st.real_file_size,
-				(unsigned int)(((double)g_mgr->ftemp_st.real_file_size / 1024) / ((double)elapsed / USEC_PER_SEC)));
+
+		ERR("mtp statistics log name: %s, file_size:%llu, speed:%u KB/s\n", g_mgr->ftemp_st.filepath, g_mgr->ftemp_st.size_remaining,
+				(unsigned int)(((double)g_mgr->ftemp_st.size_remaining / 1024) / ((double)elapsed / USEC_PER_SEC)));
 
 		__finish_receiving_file_packets(data, data_len);
 	}


### PR DESCRIPTION
## Summary
Fixed the issue that getting average speed of transferring on macOS failed.
Host may not send the SendObjectPropList (0x9808) request.
The var `ftemp_st.real_file_size` may be zero, using `g_mgr->ftemp_st.size_remaining`.
![image](https://github.com/user-attachments/assets/d50e1f32-3822-40da-b643-7b2dd563df72)


## Impact
mtp-responder

## Testing
CI


