### PR TITLE
mtp-responder: Remove unnecessary header

### DIFF
--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -33,7 +33,6 @@
 #include <sys/prctl.h>
 #include <systemd/sd-daemon.h>
 #include <unistd.h>
-#include <nuttx/config.h>
 #include <nuttx/usb/usb.h>
 /*
  * GLOBAL AND EXTERN VARIABLES


### PR DESCRIPTION
## Summary
Remove unnecessary header

## Impact
mtp-responder

## Testing
CI

