### PR TITLE
mtp-responder: Only listen to the displayed directory and fix notify init

### DIFF
--- a/include/mtp_config.h
+++ b/include/mtp_config.h
@@ -66,7 +66,7 @@
 #endif/*MTP_SUPPORT_ALBUM_ART*/
 
 /* external features */
-#define MTP_SUPPORT_OBJECTADDDELETE_EVENT
+/*#undef MTP_SUPPORT_OBJECTADDDELETE_EVENT*/
 
 /*For printing Commands sent by initiator
  *This needs to be diabled later before commercial binary release

--- a/src/mtp_entity_store.c
+++ b/src/mtp_entity_store.c
@@ -1229,7 +1229,9 @@ NEXT:
 		ERR("close directory fail");
 
 #ifdef MTP_SUPPORT_OBJECTADDDELETE_EVENT
-	_inoti_add_watch_for_fs_events(folder_name);
+	if (strlen(MTP_EXTERNAL_STORAGE_DICLIST) == 0 ||
+	    strstr(folder_name, MTP_EXTERNAL_STORAGE_DICLIST) != NULL)
+		_inoti_add_watch_for_fs_events(folder_name);
 #endif /*MTP_SUPPORT_OBJECTADDDELETE_EVENT*/
 
 	return;

--- a/src/mtp_init.c
+++ b/src/mtp_init.c
@@ -208,6 +208,10 @@ void _mtp_init(add_rem_store_t sel)
 
 	_features_supported_info();
 
+#ifdef MTP_SUPPORT_OBJECTADDDELETE_EVENT
+	_inoti_init_filesystem_evnts();
+#endif /*MTP_SUPPORT_OBJECTADDDELETE_EVENT*/
+
 	/* Install storage */
 	_device_install_storage(sel);
 
@@ -216,10 +220,6 @@ void _mtp_init(add_rem_store_t sel)
 	_hutil_get_object_handles(MTP_INTERNAL_STORE_ID, 0, PTP_OBJECTHANDLE_ALL, &handle_arr);
 	_hutil_get_object_handles(MTP_EXTERNAL_STORE_ID, 0, PTP_OBJECTHANDLE_ALL, &handle_arr);
 	_prop_deinit_ptparray(&handle_arr);
-
-#ifdef MTP_SUPPORT_OBJECTADDDELETE_EVENT
-	_inoti_init_filesystem_evnts();
-#endif /*MTP_SUPPORT_OBJECTADDDELETE_EVENT*/
 
 	vconf_ret = vconf_notify_key_changed(VCONFKEY_IDLE_LOCK_STATE_READ_ONLY,
 			_handle_lock_status_notification, NULL);


### PR DESCRIPTION
## Summary
1. Only listen to the displayed directory
2. Initialize inotify before adding a watch

Related: https://github.com/open-vela/external/pull/11

## Impact
mtp-responder

## Testing
CI
