### PR TITLE
mtp-responder: If the size of file is greater than 4 gigabytes, recving will never finished on macOS

### DIFF
--- a/src/mtp_cmd_handler.c
+++ b/src/mtp_cmd_handler.c
@@ -3354,8 +3354,8 @@ static mtp_bool __receive_temp_file_first_packet(mtp_char *data,
 	/* consider header size */
 	memcpy(&g_mgr->ftemp_st.header_buf, data, sizeof(header_container_t));
 
-	g_mgr->ftemp_st.file_size = ((header_container_t *)data)->len -
-		sizeof(header_container_t);
+	g_mgr->ftemp_st.file_size = ((header_container_t *)data)->len == 0xffffffff ?
+		((header_container_t *)data)->len : ((header_container_t *)data)->len - sizeof(header_container_t);
 	*data_sz = data_len - sizeof(header_container_t);
 
 	/* check whether last data packet */

--- a/src/mtp_cmd_handler.c
+++ b/src/mtp_cmd_handler.c
@@ -3404,7 +3404,8 @@ static mtp_bool __receive_temp_file_next_packets(mtp_char *data,
 //	if (data_len < rx_size ||
 	if (g_mgr->ftemp_st.size_remaining == g_mgr->ftemp_st.file_size ||
 			(g_mgr->ftemp_st.file_size == 0xffffffff &&
-			 g_mgr->ftemp_st.size_remaining == g_mgr->ftemp_st.real_file_size)) {
+			 (g_mgr->ftemp_st.size_remaining == g_mgr->ftemp_st.real_file_size ||
+			  (g_mgr->ftemp_st.real_file_size == 0 && data_len < _transport_get_usb_packet_len())))) {
 
 		if (_util_file_write(g_mgr->ftemp_st.fhandle, buffer, *data_sz) != *data_sz)
 			ERR("fwrite error write size=[%u]\n", *data_sz);


### PR DESCRIPTION
## Summary
1. If the size of file is greater than 4 gigabytes, recving will never finished on macOS.
The ftemp_st.file_size is 0xffffffff and the ftemp_st.real_file_size is 0x0.
2. Will get incorrect file size from SendObjectInfo when size of data is larger than 4GB

## Impact
mtp-responder

## Testing
CI
