### PR TITLE
mtp-responder: Transmission error after call incoming

### DIFF
--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -361,6 +361,11 @@ static void __handle_control_request(mtp_int32 request)
             sent_busy = FALSE;
         }
 
+        status = write(g_usb_ep0, &statusreq_data, sizeof(statusreq_data));
+        if (status < 0) {
+            ERR("IOCTL MTP_SEND_STATUS_ACK Failed [%d]\n",
+                errno);
+        }
         break;
 
     case USB_PTPREQUEST_GETEVENT:

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -361,7 +361,8 @@ static void __handle_control_request(mtp_int32 request)
             sent_busy = FALSE;
         }
 
-        if (_transport_get_mtp_operation_state() == MTP_STATE_ONSERVICE) {
+        if (_transport_get_mtp_operation_state() == MTP_STATE_ONSERVICE ||
+            _transport_get_mtp_operation_state() == MTP_STATE_DATA_TRANSFER_DL) {
             status = write(g_usb_ep0, &statusreq_data, sizeof(statusreq_data));
             if (status < 0) {
                 ERR("IOCTL MTP_SEND_STATUS_ACK Failed [%d]\n",

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -361,10 +361,12 @@ static void __handle_control_request(mtp_int32 request)
             sent_busy = FALSE;
         }
 
-        status = write(g_usb_ep0, &statusreq_data, sizeof(statusreq_data));
-        if (status < 0) {
-            ERR("IOCTL MTP_SEND_STATUS_ACK Failed [%d]\n",
-                errno);
+        if (_transport_get_mtp_operation_state() == MTP_STATE_ONSERVICE) {
+            status = write(g_usb_ep0, &statusreq_data, sizeof(statusreq_data));
+            if (status < 0) {
+                ERR("IOCTL MTP_SEND_STATUS_ACK Failed [%d]\n",
+                    errno);
+            }
         }
         break;
 


### PR DESCRIPTION
## Summary
In a weak network environment, during USB file transfer, or when connected to an incoming call, the transfer page reports an error

driver/usbdev: Support userspace writting to ep0
driver/usbdev: Some type(e.g. class) of setup(SUBMIT) of usbdev_fs always succeed

Currently a response delay of 30 seconds is supported.
![image](https://github.com/user-attachments/assets/e7226226-132c-4cd2-bb15-ea93bc89ead3)


## Impact
mtp-responder

## Testing
CI

