### PR TITLE
mtp-responder: Break loop when usb hang up and add debug info

### DIFF
--- a/src/mtp_inoti_handler.c
+++ b/src/mtp_inoti_handler.c
@@ -212,7 +212,7 @@ static mtp_bool __process_inoti_event(struct inotify_event *event)
 		ERR("path len is invalid");
 		return FALSE;
 	}
-	DBG_SECURE("Event full path = %s\n", full_path);
+	DBG_SECURE("Event full path = %s, mask = 0x%"PRIx32", cookie = 0x%"PRIx32"\n", full_path, event->mask, event->cookie);
 	if (event->mask & IN_MOVED_FROM) {
 		if (!g_strcmp0(g_last_moved, full_path)) {
 			/* Ignore this case as this is generated due to MTP*/

--- a/src/mtp_inoti_handler.c
+++ b/src/mtp_inoti_handler.c
@@ -192,7 +192,7 @@ static mtp_bool __process_inoti_event(struct inotify_event *event)
 	mtp_char parentpath[MTP_MAX_PATHNAME_SIZE + 1] = { 0 };
 
 	if (event->len == 0 || event->len > MTP_MAX_FILENAME_SIZE) {
-		ERR_SECURE("Event len is invalid[%d], event->name[%s]\n", event->len,
+		ERR_SECURE("Event len is invalid[%"PRIu32"], event->name[%s]\n", event->len,
 				event->name);
 		return FALSE;
 	} else if (event->wd < 1) {

--- a/src/mtp_transport.c
+++ b/src/mtp_transport.c
@@ -311,6 +311,7 @@ static mtp_err_t __transport_init_io(void)
 		goto cleanup;
 	}
 
+	ERR("_util_thread_create(TX) success:%d\n", g_tx_thrd);
 	res = _util_thread_create(&g_rx_thrd, "usb read thread",
 			PTHREAD_CREATE_JOINABLE, usb_read_thread,
 			(void *)&g_usb_to_mtp_mqid);
@@ -319,6 +320,7 @@ static mtp_err_t __transport_init_io(void)
 		goto cleanup;
 	}
 
+	ERR("_util_thread_create(RX) success:%d\n", g_rx_thrd);
 	if (_transport_get_type() == MTP_TRANSPORT_FFS) {
 		res = _util_thread_create(&g_ctrl_thrd, "usb control thread",
 					  PTHREAD_CREATE_JOINABLE,
@@ -328,6 +330,8 @@ static mtp_err_t __transport_init_io(void)
 			ERR("CTRL thread creation failed\n");
 			goto cleanup;
 		}
+
+		ERR("_util_thread_create(CTRL thread) success:%d\n", g_ctrl_thrd);
 	}
 
 	g_usb_threads_created = TRUE;
@@ -369,7 +373,7 @@ static void __transport_deinit_io(void)
 		if (FALSE == _util_thread_cancel(g_ctrl_thrd)) {
 			ERR("Fail to cancel pthread of g_ctrl_thrd\n");
 		} else {
-			DBG("Succeed to cancel pthread of g_ctrl_thrd\n");
+			ERR("Succeed to cancel pthread of g_ctrl_thrd\n");
 		}
 
 		if (_util_thread_join(g_ctrl_thrd, 0) == FALSE)
@@ -380,6 +384,8 @@ static void __transport_deinit_io(void)
 
 	if (FALSE == _util_thread_cancel(g_rx_thrd))
 		ERR("_util_thread_cancel(rx) Fail");
+        else
+	        ERR("Succeed to cancel pthread of rx\n");
 
 	if (_util_thread_join(g_rx_thrd, 0) == FALSE)
 		ERR("_util_thread_join(rx) Fail");
@@ -388,6 +394,8 @@ static void __transport_deinit_io(void)
 
 	if (FALSE == _util_thread_cancel(g_tx_thrd))
 		ERR("_util_thread_cancel(tx) Fail");
+        else
+	        ERR("Succeed to cancel pthread of tx\n");
 
 	if (_util_thread_join(g_tx_thrd, 0) == FALSE)
 		ERR("_util_thread_join(tx) Fail");

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -199,13 +199,12 @@ static void* ffs_transport_thread_usb_write(void* arg)
             while (written != len) {
                 status = poll(fds, 1, -1);
                 if (status < 0) {
-                    if (errno != EINTR) {
-                        ERR("USB poll fail : %d\n", errno);
-                    }
+                    ERR("USB poll fail : %d\n", errno);
                     continue;
                 }
 
                 if ((fds[0].revents & POLLHUP) == POLLHUP) {
+                    ERR("USB hang up\n");
                     break;
                 }
 

--- a/src/mtp_usb_driver_nuttx.c
+++ b/src/mtp_usb_driver_nuttx.c
@@ -194,7 +194,10 @@ static void* ffs_transport_thread_usb_write(void* arg)
          * so test for it explicitly.
          */
         pthread_testcancel();
-        _util_rcv_msg_from_mq(*mqid, &mtp_buf, &len, &mtype);
+        if (_util_rcv_msg_from_mq(*mqid, &mtp_buf, &len, &mtype) == FALSE) {
+            break;
+        }
+
         if (mtype == MTP_BULK_PACKET || mtype == MTP_DATA_PACKET) {
             while (written != len) {
                 status = poll(fds, 1, -1);
@@ -205,6 +208,7 @@ static void* ffs_transport_thread_usb_write(void* arg)
 
                 if ((fds[0].revents & POLLHUP) == POLLHUP) {
                     ERR("USB hang up\n");
+                    status = -ENOTCONN;
                     break;
                 }
 
@@ -242,7 +246,7 @@ static void* ffs_transport_thread_usb_write(void* arg)
             break;
         }
     } while (status >= 0);
-    DBG("exited Source thread with status %d\n", status);
+    ERR("exited Source thread with status %d\n", status);
     pthread_cleanup_pop(1);
     g_free(mtp_buf);
     return NULL;
@@ -276,7 +280,7 @@ static void* ffs_transport_thread_usb_read(void* arg)
             g_free(pkt.buffer);
         }
     } while (status > 0);
-    DBG("status[%d] errno[%d]\n", status, errno);
+    ERR("status[%d] errno[%d]\n", status, errno);
     pthread_cleanup_pop(1);
     return NULL;
 }

--- a/src/mtp_util_thread.c
+++ b/src/mtp_util_thread.c
@@ -99,7 +99,7 @@ mtp_bool _util_thread_cancel(pthread_t tid)
 
 	res = pthread_cancel(tid);
 	if (res != 0) {
-		ERR("pthread_cancel Fail [%lu] errno [%d]\n", (unsigned long)tid, errno);
+		ERR("pthread_cancel Fail [%lu] errno [%d]\n", (unsigned long)tid, res);
 		return FALSE;
 	}
 


### PR DESCRIPTION
## Summary
Break loop when usb hang up and add debug info

## Impact
mtp-responder

## Testing
CI

